### PR TITLE
Update synapse_get to print download progress

### DIFF
--- a/bin/synapse_get
+++ b/bin/synapse_get
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euf -o pipefail
-
+function faketty { script -qfc "$(printf "%q " "$@")" /dev/null; }
 # parse inputs and build command args
 CMD_ARGS=('synapse')
 while getopts "c:ri:q:h" ARG; do
@@ -23,5 +23,5 @@ CMD_ARGS=("${CMD_ARGS[@]}" '--downloadLocation' $SYN_DIR)
 # get file from Synapse
 COMMAND=$( IFS=' '; echo "${CMD_ARGS[*]}" );
 echo $COMMAND
-eval $COMMAND
+faketty eval $COMMAND
 echo "Downloaded files: $(find ${SYN_DIR} -mindepth 1 -maxdepth 1)"


### PR DESCRIPTION
cwltool runs container with only -i option (not -ti).
It makes sys.stdout.isatty() to return false and
suppress all output from synapsePythonClient. The
faketty function was added to synapse_get to make
all output from synapse to go through script command,
which prints it to stdout.